### PR TITLE
Fix type tests and try to fix type errors

### DIFF
--- a/lib/usecase.py
+++ b/lib/usecase.py
@@ -56,6 +56,6 @@ class BaseSingleDTOUseCase(
         else:
             responseModel: TBaseResponseModel | TBaseErrorResponseModel = self.process_dto(dto)
             if responseModel.status == False:
-                self.presenter.presentError(responseModel)  # type: ignore  # TODO: try to fix this, line 46 cannot change
+                self.presenter.presentError(responseModel)  # type: ignore
             else:
-                self.presenter.presentSuccess(responseModel)  # type: ignore  # TODO: try to fix this, line 46 cannot change
+                self.presenter.presentSuccess(responseModel)  # type: ignore

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,13 +27,10 @@ build-backend = "poetry.core.masonry.api"
 [tool.mypy]
 python_version = "3.10"
 strict = true
-warn_return_any = true
-warn_unused_configs = true
 ignore_missing_imports = true
 plugins = ["pydantic.mypy"]
 explicit_package_bases = true
-check_untyped_defs = true
-exclude = [ 
+exclude = [
   "tests/types",
 ]
 


### PR DESCRIPTION
Fixes #2

- Also: cleaned pyproject.toml from redundancies

About the ignore flags in usecase.py:

Tried a couple of techniques, including using isinstance(), but none worked, or at least not without changing substantally what we did and entering a rabbit hole of new errors.
Digging further in SO, the consensus seems to be that this kind of type check is discouraged in python.
Also, the assertion by data and not by type seems stronger and better overall.